### PR TITLE
Adding support for all real types.

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -12,7 +12,7 @@ Pages=["index.md"]
 
 This package includes a pure Julia `lowess` function, which is an implementation
 of the LOWESS smoother (references given at the end of the documentation), along with
-a `lowess_model` function can be used to make corresponding models.
+a `lowess_model` function which can be used to make corresponding models.
 
 # Tutorial
 

--- a/src/Lowess.jl
+++ b/src/Lowess.jl
@@ -283,6 +283,22 @@ function lowess(
     return ys
 end
 
+function lowess(
+    x::AbstractVector{R},
+    y::AbstractVector{S},
+    f::T = 2 / 3,
+    nsteps::Integer = 3,
+    delta::T = 0.01 * (maximum(x) - minimum(x)),
+) where {R <: Real, S <: Real, T <: AbstractFloat}
+    return lowess(
+        (R <: AbstractFloat) ? x : Vector{Float64}(x),
+        (S <: AbstractFloat) ? y : Vector{Float64}(y),
+        f,
+        nsteps,
+        delta
+    )
+end
+
 """
 ```julia
 lowess_model(xs, ys, f = 2 / 3, nsteps = 3, delta = 0.01 * (maximum(xs) - minimum(xs)))
@@ -315,33 +331,4 @@ function lowess_model(xs, ys, f = 2 / 3, nsteps = 3, delta = 0.01 * (maximum(xs)
     return prediction_model
 end
 
-function lowess(
-    x::AbstractVector{Int},
-    y::AbstractVector{T},
-    f::T = 2 / 3,
-    nsteps::Integer = 3,
-    delta::T = 0.01 * (maximum(x) - minimum(x))
-) where {T <: AbstractFloat}
-    return lowess(Vector{Float64}(x), y, f, nsteps, delta)
-end
-
-function lowess(
-    x::AbstractVector{T},
-    y::AbstractVector{Int},
-    f::T = 2 / 3,
-    nsteps::Integer = 3,
-    delta::T = 0.01 * (maximum(x) - minimum(x))
-) where {T <: AbstractFloat}
-    return lowess(x, Vector{Float64}(y), f, nsteps, delta)
-end
-
-function lowess(
-    x::AbstractVector{Int},
-    y::AbstractVector{Int},
-    f::T = 2 / 3,
-    nsteps::Integer = 3,
-    delta::T = 0.01 * (maximum(x) - minimum(x))
-) where {T <: AbstractFloat}
-    return lowess(Vector{Float64}(x), Vector{Float64}(y), f, nsteps, delta)
-end
 end


### PR DESCRIPTION
In this PR a new method for `lowess` has been added which supports all possible real types for the input vectors `x` and `y`  to `lowess`. This also reduces the three methods to just one method. 

A minor grammatical mistake in the docs is also fixed.