### PR TITLE
Remove benchmarks

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -18,7 +18,6 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
-Clarity is required on the license and copyright. 
 The original FORTRAN code can be found here: https://www.netlib.org/go/lowess.f 
-The C code was found here: https://github.com/blindglobe/common-lisp-stat, but it has been deleted. 
+The C code can be found here: https://github.com/carlohamalainen/cl-lowess/blob/master/lowess.c 
 

--- a/README.md
+++ b/README.md
@@ -51,10 +51,10 @@ vs = predict(model, us)
 end 
 ```
 ```
-BenchmarkTools.Trial: 6040 samples with 1 evaluation.
- Range (min … max):  574.949 μs …   3.726 ms  ┊ GC (min … max):  0.00% … 64.41%
- Time  (median):     693.659 μs               ┊ GC (median):     0.00%
- Time  (mean ± σ):   825.584 μs ± 515.006 μs  ┊ GC (mean ± σ):  16.85% ± 18.90%
+BenchmarkTools.Trial: 10000 samples with 1 evaluation.
+ Range (min … max):  172.354 μs …   1.783 ms  ┊ GC (min … max):  0.00% … 86.02%
+ Time  (median):     186.823 μs               ┊ GC (median):     0.00%
+ Time  (mean ± σ):   215.683 μs ± 176.942 μs  ┊ GC (mean ± σ):  11.76% ± 12.18%
 ```
 
 ```julia

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ plot!(us, vs, legend=false)
 # Benchmarks
 
 ```julia
-using BenchmarkTools, using Loess, using Lowess
+using BenchmarkTools, Loess, Lowess
 xs = 10 .* rand(100)
 xs = sort(xs)
 ys = sin.(xs) .+ 0.5 * rand(100)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Lowess
 
-## Clarity is required on the copyright and license. 
-
 [![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://xKDR.github.io/Lowess.jl/dev)
 ![Build Status](https://github.com/xKDR/Lowess.jl/actions/workflows/ci.yml/badge.svg)
 ![Build Status](https://github.com/xKDR/Lowess.jl/actions/workflows/documentation.yml/badge.svg)


### PR DESCRIPTION
After [PR #68](https://github.com/JuliaStats/Loess.jl/pull/68) in Loess.jl, Lowess.jl isn't much faster any more. 

